### PR TITLE
Upgrade to nom >=7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["parser", "properties", "dotproperties"]
 categories = ["parser-implementations", "config"]
 
 [dependencies]
-nom = "6"
+nom = "7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! assert_eq!("value3", properties.get("key3").unwrap());
 //! ```
 #![deny(missing_docs)]
-#![deny(missing_crate_level_docs)]
+#![deny(rustdoc::missing_crate_level_docs)]
 
 mod parser;
 pub use parser::Property;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -157,7 +157,7 @@ pub fn parser(input: &[u8]) -> IResult<&[u8], Vec<Property>> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use nom::dbg_dmp;
+    use nom::error::dbg_dmp;
 
     macro_rules! assert_done {
         ($t:expr, $v:expr) => {


### PR DESCRIPTION
Good news: not much to update. Just one test dep
from nom that changed namespaces

Also, updated a deny to rust 1.67's new name.